### PR TITLE
Update conference link for OTC 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
       <li><a href="http://docs.opentripplanner.org"><i class="fa fa-info"></i> Docs</a></li>
       <li><a href="https://docs.opentripplanner.org/en/dev-2.x/#getting-help"><i class="fa fa-question"></i> Support</a></li>
       <li><a href="https://docs.opentripplanner.org/en/dev-2.x/Product-Overview/"><i class="fa fa-map"></i> Overview</a></li>
-      <li><a href="https://www.opentripplanner.org/helsinki2025/"><i class="fa fa-handshake"></i> OTP Conference 2025</a></li>	  
+      <li><a href="https://open-transport.org/"><i class="fa fa-handshake"></i> OTC Conference 2026</a></li>
     </ul>
     <div class="text-column">
       <p>OpenTripPlanner (OTP) is a family of open source software projects that provide passenger information and transportation network analysis services. The core server-side Java component finds itineraries combining transit, pedestrian, bicycle, and car segments through networks built from widely available, open standard OpenStreetMap and GTFS data. This service can be accessed directly via its web API or using a range of Javascript client libraries, including modern reactive modular components targeting mobile platforms.</p>


### PR DESCRIPTION
This updates the conference to the upcoming OTC conference later this year.

I chose the link directly to the main page https://open-transport.org/, even though this isn't specific to the conference. It's just a landing page for the organization. But it is the one that contains the most information about the upcoming event, so it seems best regardless. Alternatively there is https://pretix.eu/fossgis/open-transport-2026/ which would be more direct.

I changed the text to say OTC conference rather than OTP conference.